### PR TITLE
Fix marco bugs

### DIFF
--- a/src/http_fetch.rs
+++ b/src/http_fetch.rs
@@ -220,7 +220,7 @@ impl DataLoader for HTTPDataLoader {
             let full_path = path_join(vec![&path, &request.0]).unwrap();
             console::log_1(&format!("Requesting {:?}", full_path).into());
 
-            let mut request_options = RequestInit::new();
+            let request_options = RequestInit::new();
             request_options.set_method("GET");
             request_options.set_mode(RequestMode::Cors);
 
@@ -228,7 +228,7 @@ impl DataLoader for HTTPDataLoader {
                 &full_path,
                 &request_options).unwrap();
 
-            req.headers().set("Range",
+            let _ = req.headers().set("Range",
                 &format!("bytes={}-{}", request.1, request.2));
 
             console::log_1(&format!("Request: {:?}", req).into());

--- a/src/http_fetch.rs
+++ b/src/http_fetch.rs
@@ -164,13 +164,13 @@ impl NgPreHTTPFetch {
         NgPrePromiseReader::dataset_exists(self, path_name).await
     }
 
-    pub fn read_block(
+    pub async fn read_block(
         &self,
         path_name: &str,
         data_attrs: &wrapped::DatasetAttributes,
         grid_position: Vec<i64>,
     ) -> Promise {
-        NgPrePromiseReader::read_block(self, path_name, data_attrs, grid_position)
+        NgPrePromiseReader::read_block(self, path_name, data_attrs, grid_position).await
     }
 
     pub async fn list_attributes(&self, path_name: &str) -> Promise {
@@ -187,14 +187,14 @@ impl NgPreHTTPFetch {
             self, path_name, data_attrs, grid_position).await
     }
 
-    pub fn read_block_with_etag(
+    pub async fn read_block_with_etag(
         &self,
         path_name: &str,
         data_attrs: &wrapped::DatasetAttributes,
         grid_position: Vec<i64>,
     ) -> Promise {
         NgPrePromiseEtagReader::read_block_with_etag(
-            self, path_name, data_attrs, grid_position)
+            self, path_name, data_attrs, grid_position).await
     }
 }
 
@@ -343,7 +343,7 @@ impl NgPreAsyncEtagReader for NgPreHTTPFetch {
         _data_attrs: &DatasetAttributes,
         grid_position: UnboundedGridCoord,
     ) -> Option<String> {
-        let mut request_options = RequestInit::new();
+        let request_options = RequestInit::new();
         request_options.set_method("HEAD");
         request_options.set_mode(RequestMode::Cors);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,11 +211,6 @@ pub trait NgPreAsyncEtagReader {
                 T: ReflectedType;
 }
 
-
-fn convert_jsvalue_error(error: JsValue) -> Error {
-    Error::new(std::io::ErrorKind::Other, format!("{:?}", error))
-}
-
 pub mod wrapped {
     use super::*;
 


### PR DESCRIPTION
This pull request solves the `data_type_match!` macro bugs.

Some notable changes are:
- `data_type_match` macro now takes a `.clone()` value because the `&self` escapes the method function body:
```rust
let to_return = self.read_block(path_name, &data_attrs.0, grid_position.into()).map(|val: Option<SliceDataBlock<i64, Vec<i64>>>| {
    Ok(JsValue::from(val.unwrap().into_data()))
}).await.clone();

data_type_match! {
    data_attrs.0.get_data_type(),
    future_to_promise(future::ready(to_return))
}
```
- Ignoring `async trait function` compiler warnings: `#[allow(async_fn_in_trait)]`

## Async Trait Function warnings
The reason that Rust doesn't allow `async fn` in a Trait is because `async fn` can resume and start their execution on different threads, because of this behavior the function definitions in the Trait can't enforce the `Send` Trait, and also it's not applied automatically for other Traits as well, because the size of function is unknown at compile time. Because Rust does not automatically infer these bounds, the Trait's API could break if you enforce those bounds later on.

For now, ignoring these warnings is fine because the all the trait functions returns a `wasm::bindgen` **Promise** value.

## Solution
There are ways to get around this, but those have their own trade-offs:
- The [async-trait](https://crates.io/crates/async-trait) provides an attribute macro that would turn a `aync fn` implementation into a `Pin<Box<dyn Future + Send + 'async_trait>>`, but this introduces a pointer indirection + the `Future` is heap allocated.