### PR TITLE
Fixing types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ serde_derive = "1.0"
 serde_json = "1.0"
 wasm-bindgen = { version = "0.2" }
 wasm-bindgen-futures = "0.4"
+ngpre = { git = "https://github.com/tomka/rust-ngpre", branch = "sharding", features = ["gzip", "jpeg"], default-features = false }
+
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
@@ -34,12 +36,6 @@ serde-wasm-bindgen = "0.6.5"
 zune-core = "0.4.12"
 zune-image = "0.4.15"
 itertools = "0.13.0"
-
-[dependencies.ngpre]
-path = "../rust-ngpre"
-#version = "0.0.1"
-default-features = false
-features = ["gzip", "jpeg"]
 
 [dependencies.web-sys]
 version = "0.3.70"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ crate-type = ["cdylib", "rlib"]
 default = []
 
 [dependencies]
-cfg-if = "0.1.2"
 futures = "0.3"
 js-sys = "0.3.33"
 serde = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["tensor"]
 categories = ["encoding", "filesystem", "science", "wasm"]
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [features]
 default = []

--- a/src/http_fetch.rs
+++ b/src/http_fetch.rs
@@ -66,14 +66,14 @@ impl NgPreHTTPFetch {
         let resp_value = self.fetch(path_name);
         assert!(resp_value.is_instance_of::<Response>());
         let resp: Response = resp_value.dyn_into().unwrap();
-        resp.json().unwrap().into()
+        resp.json().expect("failed parse JSON").into()
     }
 
     fn get_attributes(&self, path_name: &str) -> serde_json::Value {
         utils::set_panic_hook();
         let path = self.get_dataset_attributes_path(path_name);
         let js_val = self.fetch_json(&path);
-        serde_wasm_bindgen::from_value(js_val).unwrap()
+        serde_wasm_bindgen::from_value(js_val).expect("failed to convert javascript type into rust type")
     }
 
     fn relative_block_path(&self, path_name: &str, grid_position: &[i64], block_size: &[u32], voxel_offset: &[i32], dimensions: &[u64]) -> String {

--- a/src/http_fetch.rs
+++ b/src/http_fetch.rs
@@ -1,8 +1,8 @@
+use futures::future::{self, Either};
+use futures::TryFutureExt;
 use std::fmt::Write;
 use std::str::FromStr;
-use std::cmp;
-use futures::future::{self, FutureExt, Either};
-use futures::TryFutureExt;
+use std::{cmp, io};
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -10,21 +10,11 @@ use std::path::PathBuf;
 use js_sys::ArrayBuffer;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
-use web_sys::{
-    Request,
-    RequestInit,
-    RequestMode,
-    Response,
-    console,
-};
+use web_sys::{console, Request, RequestInit, RequestMode, Response};
 
 use super::*;
 
-use ngpre::{
-    DataLoader,
-    DataLoaderResult,
-};
-
+use ngpre::{DataLoader, DataLoaderResult};
 
 const ATTRIBUTES_FILE: &str = "info";
 

--- a/src/http_fetch.rs
+++ b/src/http_fetch.rs
@@ -300,12 +300,11 @@ impl NgPreAsyncReader for NgPreHTTPFetch {
         unimplemented!()
     }
 
-    async fn list_attributes(
+    fn list_attributes(
         &self,
         path_name: &str,
     ) -> serde_json::Value {
-
-        self.get_attributes(path_name).await
+        self.get_attributes(path_name)
     }
 }
 

--- a/src/http_fetch.rs
+++ b/src/http_fetch.rs
@@ -12,7 +12,6 @@ use wasm_bindgen_futures::JsFuture;
 use web_sys::{console, Request, RequestInit, RequestMode, Response};
 
 use super::*;
-
 use ngpre::{DataLoader, DataLoaderResult};
 
 const ATTRIBUTES_FILE: &str = "info";
@@ -98,7 +97,7 @@ impl NgPreHTTPFetch {
 
     fn get_dataset_attributes_path(&self, path_name: &str) -> String {
         if path_name.is_empty() {
-            return ATTRIBUTES_FILE.to_owned()
+            return ATTRIBUTES_FILE.to_string()
         }
 
         // There is only one top-level attribute file
@@ -212,7 +211,6 @@ impl DataLoader for HTTPDataLoader {
             //let completed_req = futures::executor::block_on(f);
             //assert!(completed_req.is_instance_of::<Response>());
             //let resp: Response = completed_req.dyn_into().unwrap();
-
 
 
             //let json = JsFuture::from(resp.json()?).await?;
@@ -366,7 +364,7 @@ impl NgPreAsyncEtagReader for NgPreHTTPFetch {
                     return None;
                 }
                 offset_grid_position.push(coord as u64);
-                n = n + 1;
+                n += 1;
             }
             console::log_2(&"offset_grid_position".into(), &format!("{:?}", &offset_grid_position).into());
 
@@ -474,7 +472,7 @@ impl NgPreAsyncEtagReader for NgPreHTTPFetch {
                 return None;
             }
             offset_grid_position.push(coord as u64);
-            n = n + 1;
+            n += 1;
         }
 
         console::log_1(&"read_block_with etag".into());
@@ -486,7 +484,7 @@ impl NgPreAsyncEtagReader for NgPreHTTPFetch {
 
         if resp.ok() {
             let etag: Option<String> = resp.headers().get("ETag").unwrap_or(None);
-            let to_return = JsFuture::from(resp.array_buffer().unwrap())
+            return JsFuture::from(resp.array_buffer().unwrap())
                 .map_ok(move |arrbuff_value| {
                     assert!(arrbuff_value.is_instance_of::<ArrayBuffer>());
                     let typebuff: js_sys::Uint8Array = js_sys::Uint8Array::new(&arrbuff_value);
@@ -497,10 +495,9 @@ impl NgPreAsyncEtagReader for NgPreHTTPFetch {
                         &da2,
                         offset_grid_position).unwrap(),
                         etag))
-                });
-            return to_return.await.unwrap()
+                }).await.unwrap();
         }
 
-        None
+        return None
     }
 }

--- a/src/http_fetch.rs
+++ b/src/http_fetch.rs
@@ -60,19 +60,17 @@ impl NgPreHTTPFetch {
         self_().unwrap().fetch_with_request(&req)
     }
 
-    async fn fetch_json(&self, path_name: &str) -> JsValue {
-        let resp_value = self.fetch(path_name).await.unwrap();
+    fn fetch_json(&self, path_name: &str) -> JsValue {
+        let resp_value = self.fetch(path_name);
         assert!(resp_value.is_instance_of::<Response>());
         let resp: Response = resp_value.dyn_into().unwrap();
-        let json_val = JsFuture::from(resp.json().unwrap()).await.unwrap();
-
-        json_val
+        resp.json().unwrap().into()
     }
 
-    async fn get_attributes(&self, path_name: &str) -> serde_json::Value {
+    fn get_attributes(&self, path_name: &str) -> serde_json::Value {
         utils::set_panic_hook();
         let path = self.get_dataset_attributes_path(path_name);
-        let js_val = self.fetch_json(&path).await;
+        let js_val = self.fetch_json(&path);
         serde_wasm_bindgen::from_value(js_val).unwrap()
     }
 

--- a/src/http_fetch.rs
+++ b/src/http_fetch.rs
@@ -170,9 +170,7 @@ impl NgPreHTTPFetch {
     }
 }
 
-struct HTTPDataLoader {
-
-}
+struct HTTPDataLoader {}
 
 fn path_join(paths: Vec<&str>) -> Option<String> {
     let mut path = PathBuf::new();

--- a/src/http_fetch.rs
+++ b/src/http_fetch.rs
@@ -49,6 +49,7 @@ pub struct NgPreHTTPFetch {
 
 impl NgPreHTTPFetch {
     fn fetch(&self, path_name: &str) -> Promise {
+        utils::set_panic_hook();
         let request_options = RequestInit::new();
         request_options.set_method("GET");
         request_options.set_mode(RequestMode::Cors);
@@ -61,6 +62,7 @@ impl NgPreHTTPFetch {
     }
 
     fn fetch_json(&self, path_name: &str) -> JsValue {
+        utils::set_panic_hook();
         let resp_value = self.fetch(path_name);
         assert!(resp_value.is_instance_of::<Response>());
         let resp: Response = resp_value.dyn_into().unwrap();
@@ -97,17 +99,19 @@ impl NgPreHTTPFetch {
 
     fn get_dataset_attributes_path(&self, path_name: &str) -> String {
         if path_name.is_empty() {
-            ATTRIBUTES_FILE.to_owned()
-        } else {
-            // There is only one top-level attribute file
-            format!("{}", ATTRIBUTES_FILE)
+            return ATTRIBUTES_FILE.to_owned()
         }
+
+        // There is only one top-level attribute file
+        ATTRIBUTES_FILE.to_string()
     }
 }
 
 #[wasm_bindgen]
 impl NgPreHTTPFetch {
     pub async fn open(base_path: &str) -> Result<JsValue, JsValue> {
+        utils::set_panic_hook();
+
         let reader = NgPreHTTPFetch {
             base_path: base_path.into(),
         };

--- a/src/http_fetch.rs
+++ b/src/http_fetch.rs
@@ -48,7 +48,7 @@ pub struct NgPreHTTPFetch {
 }
 
 impl NgPreHTTPFetch {
-    fn fetch(&self, path_name: &str) -> JsFuture {
+    fn fetch(&self, path_name: &str) -> Promise {
         let request_options = RequestInit::new();
         request_options.set_method("GET");
         request_options.set_mode(RequestMode::Cors);
@@ -57,9 +57,7 @@ impl NgPreHTTPFetch {
             &format!("{}/{}", &self.base_path, path_name),
             &request_options).unwrap();
 
-        let req_promise = self_().unwrap().fetch_with_request(&req);
-
-        JsFuture::from(req_promise)
+        self_().unwrap().fetch_with_request(&req)
     }
 
     async fn fetch_json(&self, path_name: &str) -> JsValue {

--- a/src/http_fetch.rs
+++ b/src/http_fetch.rs
@@ -141,7 +141,7 @@ impl NgPreHTTPFetch {
         path_name: &str,
         data_attrs: &wrapped::DatasetAttributes,
         grid_position: Vec<i64>,
-    ) -> Promise {
+    ) -> JsValue {
         NgPrePromiseReader::read_block(self, path_name, data_attrs, grid_position).await
     }
 
@@ -154,7 +154,7 @@ impl NgPreHTTPFetch {
         path_name: &str,
         data_attrs: &wrapped::DatasetAttributes,
         grid_position: Vec<i64>,
-    ) -> Promise {
+    ) -> JsValue {
         NgPrePromiseEtagReader::block_etag(
             self, path_name, data_attrs, grid_position).await
     }
@@ -164,9 +164,8 @@ impl NgPreHTTPFetch {
         path_name: &str,
         data_attrs: &wrapped::DatasetAttributes,
         grid_position: Vec<i64>,
-    ) -> Promise {
-        NgPrePromiseEtagReader::read_block_with_etag(
-            self, path_name, data_attrs, grid_position).await
+    ) -> JsValue {
+        NgPrePromiseEtagReader::read_block_with_etag(self, path_name, data_attrs, grid_position).await
     }
 }
 

--- a/src/http_fetch.rs
+++ b/src/http_fetch.rs
@@ -43,7 +43,6 @@ fn self_() -> Result<GlobalProxy, JsValue> {
 
 
 #[wasm_bindgen]
-#[derive(Clone)]
 pub struct NgPreHTTPFetch {
     base_path: String,
 }

--- a/src/http_fetch.rs
+++ b/src/http_fetch.rs
@@ -120,23 +120,20 @@ impl NgPreHTTPFetch {
         return Ok(JsValue::from(reader))
     }
 
-/// Delegations to expose NgPrePromiseReader trait to WASM.
-#[wasm_bindgen]
-impl NgPreHTTPFetch {
-    pub async fn get_version(&self) -> Promise {
-        NgPrePromiseReader::get_version(self).await
+    pub fn get_version(&self) -> JsValue {
+        NgPrePromiseReader::get_version(self)
     }
 
-    pub async fn get_dataset_attributes(&self, path_name: &str) -> Promise {
-        NgPrePromiseReader::get_dataset_attributes(self, path_name).await
+    pub fn get_dataset_attributes(&self, path_name: &str) -> JsValue {
+        NgPrePromiseReader::get_dataset_attributes(self, path_name)
     }
 
-    pub async fn exists(&self, path_name: &str) -> Promise {
-        NgPrePromiseReader::exists(self, path_name).await
+    pub fn exists(&self, path_name: &str) -> bool {
+        NgPrePromiseReader::exists(self, path_name)
     }
 
-    pub async fn dataset_exists(&self, path_name: &str) -> Promise {
-        NgPrePromiseReader::dataset_exists(self, path_name).await
+    pub fn dataset_exists(&self, path_name: &str) -> bool {
+        NgPrePromiseReader::dataset_exists(self, path_name)
     }
 
     pub async fn read_block(

--- a/src/http_fetch.rs
+++ b/src/http_fetch.rs
@@ -35,11 +35,10 @@ impl GlobalProxy {
 fn self_() -> Result<GlobalProxy, JsValue> {
     let global = js_sys::global();
     if js_sys::eval("typeof WorkerGlobalScope !== 'undefined'")?.as_bool().unwrap() {
-        Ok(global.dyn_into::<web_sys::WorkerGlobalScope>().map(GlobalProxy::WorkerGlobalScope)?)
+        return Ok(global.dyn_into::<web_sys::WorkerGlobalScope>().map(GlobalProxy::WorkerGlobalScope)?)
     }
-    else {
-        Ok(global.dyn_into::<web_sys::Window>().map(GlobalProxy::Window)?)
-    }
+
+    Ok(global.dyn_into::<web_sys::Window>().map(GlobalProxy::Window)?)
 }
 
 

--- a/src/http_fetch.rs
+++ b/src/http_fetch.rs
@@ -179,7 +179,7 @@ fn path_join(paths: Vec<&str>) -> Option<String> {
 
 impl DataLoader for HTTPDataLoader {
     fn get(&self, path: String, progress: Option<bool>, tuples: Vec<(String, u64, u64)>, num: usize)
-        -> HashMap<String, Result<DataLoaderResult, Error>> {
+        -> HashMap<String, io::Result<DataLoaderResult>> {
 
         let result = HashMap::new();
         console::log_1(&format!("HTTPDataLoader {:?} num: {:?}", &path, num).into());

--- a/src/http_fetch.rs
+++ b/src/http_fetch.rs
@@ -235,12 +235,9 @@ impl DataLoader for HTTPDataLoader {
 }
 
 impl NgPreAsyncReader for NgPreHTTPFetch {
-    async fn get_version(&self) -> ngpre::Version {
-        let to_return = self.get_attributes("").map(|_attr| {
-                ngpre::Version::from_str(&"2.3.0").unwrap()
-            }).await;
-
-        to_return
+    fn get_version(&self) -> ngpre::Version {
+        self.get_attributes("");
+        ngpre::Version::from_str(&"2.3.0").unwrap()
     }
 
     async fn get_dataset_attributes(&self, path_name: &str) ->

--- a/src/http_fetch.rs
+++ b/src/http_fetch.rs
@@ -111,21 +111,18 @@ impl NgPreHTTPFetch {
 
 #[wasm_bindgen]
 impl NgPreHTTPFetch {
-    pub async fn open(base_path: &str) -> Promise {
+    pub async fn open(base_path: &str) -> Result<JsValue, JsValue> {
         let reader = NgPreHTTPFetch {
             base_path: base_path.into(),
         };
 
-        let version = NgPreAsyncReader::get_version(&reader).await;
-        let to_return = if !ngpre::is_version_compatible(&ngpre::VERSION, &version) {
-            future::err(JsValue::from("TODO: Incompatible version"))
-        } else {
-            future::ok(JsValue::from(reader))
+        let version = NgPreAsyncReader::get_version(&reader);
+        if !ngpre::is_version_compatible(&ngpre::VERSION, &version) {
+            return Err(JsValue::from("TODO: Incompatible version"));
         };
 
-        future_to_promise(to_return)
+        return Ok(JsValue::from(reader))
     }
-}
 
 /// Delegations to expose NgPrePromiseReader trait to WASM.
 #[wasm_bindgen]

--- a/src/http_fetch.rs
+++ b/src/http_fetch.rs
@@ -32,12 +32,6 @@ impl GlobalProxy {
     }
 }
 
-macro_rules! log {
-    ( $( $t:tt )* ) => {
-        web_sys::console::log_1(&format!( $( $t )* ).into());
-    }
-}
-
 fn self_() -> Result<GlobalProxy, JsValue> {
     let global = js_sys::global();
     if js_sys::eval("typeof WorkerGlobalScope !== 'undefined'")?.as_bool().unwrap() {

--- a/src/http_fetch.rs
+++ b/src/http_fetch.rs
@@ -145,8 +145,8 @@ impl NgPreHTTPFetch {
         NgPrePromiseReader::read_block(self, path_name, data_attrs, grid_position).await
     }
 
-    pub async fn list_attributes(&self, path_name: &str) -> Promise {
-        NgPrePromiseReader::list_attributes(self, path_name).await
+    pub fn list_attributes(&self, path_name: &str) -> JsValue {
+        NgPrePromiseReader::list_attributes(self, path_name)
     }
 
     pub async fn block_etag(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,13 +17,13 @@ use ngpre::{data_type_match, data_type_rstype_replace};
 #[allow(async_fn_in_trait)]
 pub trait NgPrePromiseReader {
     /// Get the NgPre specification version of the container.
-    fn get_version(&self) -> JsValue;
+    async fn get_version(&self) -> JsValue;
 
-    fn get_dataset_attributes(&self, path_name: &str) -> JsValue;
+    async fn get_dataset_attributes(&self, path_name: &str) -> JsValue;
 
-    fn exists(&self, path_name: &str) -> bool;
+    async fn exists(&self, path_name: &str) -> bool;
 
-    fn dataset_exists(&self, path_name: &str) -> bool;
+    async fn dataset_exists(&self, path_name: &str) -> bool;
 
     async fn read_block(
         &self,
@@ -32,27 +32,27 @@ pub trait NgPrePromiseReader {
         grid_position: Vec<i64>,
     ) -> JsValue;
 
-    fn list_attributes(&self, path_name: &str) -> JsValue;
+    async fn list_attributes(&self, path_name: &str) -> JsValue;
 }
 
 impl<T> NgPrePromiseReader for T where T: NgPreAsyncReader {
-    fn get_version(&self) -> JsValue {
+    async fn get_version(&self) -> JsValue {
         utils::set_panic_hook();
-        let ver = self.get_version();
+        let ver = self.get_version().await;
         JsValue::from(wrapped::Version(ver))
     }
 
-    fn get_dataset_attributes(&self, path_name: &str) -> JsValue {
-        let attrs = self.get_dataset_attributes(path_name);
+    async fn get_dataset_attributes(&self, path_name: &str) -> JsValue {
+        let attrs = self.get_dataset_attributes(path_name).await;
         JsValue::from(wrapped::DatasetAttributes(attrs))
     }
 
-    fn exists(&self, path_name: &str) -> bool {
-        self.exists(path_name)
+    async fn exists(&self, path_name: &str) -> bool {
+        self.exists(path_name).await
     }
 
-    fn dataset_exists(&self, path_name: &str) -> bool {
-        self.dataset_exists(path_name)
+    async fn dataset_exists(&self, path_name: &str) -> bool {
+        self.dataset_exists(path_name).await
     }
 
     async fn read_block(
@@ -71,12 +71,12 @@ impl<T> NgPrePromiseReader for T where T: NgPreAsyncReader {
         }
     }
 
-    fn list_attributes(
+    async fn list_attributes(
         &self,
         path_name: &str,
     ) -> JsValue {
         // TODO: Superfluous conversion from JSON to JsValue to serde to JsValue.
-        let list_attrs = self.list_attributes(path_name);
+        let list_attrs = self.list_attributes(path_name).await;
         serde_wasm_bindgen::to_value(&list_attrs).unwrap()
     }
 }
@@ -133,14 +133,14 @@ impl<T> NgPrePromiseEtagReader for T where T: NgPreAsyncEtagReader {
 /// with an NgPre core async trait.
 #[allow(async_fn_in_trait)]
 pub trait NgPreAsyncReader {
-    fn get_version(&self) -> ngpre::Version;
+    async fn get_version(&self) -> ngpre::Version;
 
-    fn get_dataset_attributes(&self, path_name: &str) -> ngpre::DatasetAttributes;
+    async fn get_dataset_attributes(&self, path_name: &str) -> ngpre::DatasetAttributes;
 
-    fn exists(&self, path_name: &str) -> bool;
+    async fn exists(&self, path_name: &str) -> bool;
 
     // TODO: FIX ME
-    fn dataset_exists(&self, path_name: &str) -> bool {
+    async fn dataset_exists(&self, path_name: &str) -> bool {
         unimplemented!("what boolean value to return? {path_name}")
     }
 
@@ -155,7 +155,7 @@ pub trait NgPreAsyncReader {
 
     async fn list(&self, path_name: &str) -> Vec<String>;
 
-    fn list_attributes(&self, path_name: &str) -> serde_json::Value;
+    async fn list_attributes(&self, path_name: &str) -> serde_json::Value;
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,14 +42,10 @@ pub trait NgPrePromiseReader {
 }
 
 impl<T> NgPrePromiseReader for T where T: NgPreAsyncReader {
-    async fn get_version(&self) -> Promise {
+    fn get_version(&self) -> JsValue {
         utils::set_panic_hook();
-        let version = self.get_version().await;
-        let to_return = async move {
-            Ok(JsValue::from(wrapped::Version(version)))
-        };
-
-        future_to_promise(to_return)
+        let ver = self.get_version();
+        JsValue::from(wrapped::Version(ver))
     }
 
     fn get_dataset_attributes(&self, path_name: &str) -> JsValue {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ use wasm_bindgen;
 use wasm_bindgen_futures;
 use web_sys;
 
+pub mod http_fetch;
 mod utils;
 
 use js_sys::Promise;
@@ -12,9 +13,6 @@ use wasm_bindgen::prelude::*;
 
 use ngpre::prelude::*;
 use ngpre::{data_type_match, data_type_rstype_replace};
-
-
-pub mod http_fetch;
 
 #[allow(async_fn_in_trait)]
 pub trait NgPrePromiseReader {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,8 +198,9 @@ pub trait NgPreAsyncEtagReader {
         data_attrs: &DatasetAttributes,
         grid_position: UnboundedGridCoord,
     ) -> Option<(VecDataBlock<T>, Option<String>)>
-            where VecDataBlock<T>: DataBlock<T> + ngpre::ReadableDataBlock,
-                T: ReflectedType;
+    where
+        VecDataBlock<T>: DataBlock<T> + ngpre::ReadableDataBlock,
+        T: ReflectedType;
 }
 
 pub mod wrapped {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,19 +79,13 @@ impl<T> NgPrePromiseReader for T where T: NgPreAsyncReader {
         }
     }
 
-    async fn list_attributes(
+    fn list_attributes(
         &self,
         path_name: &str,
-    ) -> Promise {
-
+    ) -> JsValue {
         // TODO: Superfluous conversion from JSON to JsValue to serde to JsValue.
-        let list_attrs = self.list_attributes(path_name).await;
-        let to_return = async move {
-            let val = serde_wasm_bindgen::to_value(&list_attrs).unwrap();
-            Ok(JsValue::from(val))
-        };
-
-        future_to_promise(to_return)
+        let list_attrs = self.list_attributes(path_name);
+        serde_wasm_bindgen::to_value(&list_attrs).unwrap()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
-use futures::{self, future, FutureExt};
+use futures::{self, FutureExt};
 use js_sys;
-use ngpre;
 use serde_json;
 use wasm_bindgen;
 use wasm_bindgen_futures;
@@ -8,11 +7,8 @@ use web_sys;
 
 mod utils;
 
-use std::io::Error;
-
 use js_sys::Promise;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen_futures::future_to_promise;
 
 use ngpre::prelude::*;
 use ngpre::{data_type_match, data_type_rstype_replace};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,7 +194,7 @@ pub trait NgPreAsyncReader {
 
     async fn list(&self, path_name: &str) -> Vec<String>;
 
-    async fn list_attributes(&self, path_name: &str) -> serde_json::Value;
+    fn list_attributes(&self, path_name: &str) -> serde_json::Value;
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,16 +171,15 @@ impl<T> NgPrePromiseEtagReader for T where T: NgPreAsyncEtagReader {
 /// with an NgPre core async trait.
 #[allow(async_fn_in_trait)]
 pub trait NgPreAsyncReader {
-    async fn get_version(&self) -> ngpre::Version;
+    fn get_version(&self) -> ngpre::Version;
 
-    async fn get_dataset_attributes(&self, path_name: &str) -> ngpre::DatasetAttributes;
+    fn get_dataset_attributes(&self, path_name: &str) -> ngpre::DatasetAttributes;
 
-    async fn exists(&self, path_name: &str) -> bool;
+    fn exists(&self, path_name: &str) -> bool;
 
     // TODO: FIX ME
-    async fn dataset_exists(&self, path_name: &str) -> bool {
-        self.get_dataset_attributes(path_name)
-            .map(|_| true).map(|x| x && x).await
+    fn dataset_exists(&self, path_name: &str) -> bool {
+        unimplemented!("what boolean value to return? {path_name}")
     }
 
     async fn read_block<T>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,31 +52,17 @@ impl<T> NgPrePromiseReader for T where T: NgPreAsyncReader {
         future_to_promise(to_return)
     }
 
-    async fn get_dataset_attributes(&self, path_name: &str) -> Promise {
-        let attrs = self.get_dataset_attributes(path_name).await;
-        let to_return = async move {
-            Ok(JsValue::from(wrapped::DatasetAttributes(attrs)))
-        };
-
-        future_to_promise(to_return)
+    fn get_dataset_attributes(&self, path_name: &str) -> JsValue {
+        let attrs = self.get_dataset_attributes(path_name);
+        JsValue::from(wrapped::DatasetAttributes(attrs))
     }
 
-    async fn exists(&self, path_name: &str) -> Promise {
-        let exists = self.exists(path_name).await;
-        let to_return = async move {
-            Ok(JsValue::from(exists))
-        };
-
-        future_to_promise(to_return)
+    fn exists(&self, path_name: &str) -> bool {
+        self.exists(path_name)
     }
 
-    async fn dataset_exists(&self, path_name: &str) -> Promise {
-        let exists = self.dataset_exists(path_name).await;
-        let to_return = async move {
-            Ok(JsValue::from(exists))
-        };
-
-        future_to_promise(to_return)
+    fn dataset_exists(&self, path_name: &str) -> bool {
+        self.dataset_exists(path_name)
     }
 
     async fn read_block(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,22 +23,22 @@ pub mod http_fetch;
 #[allow(async_fn_in_trait)]
 pub trait NgPrePromiseReader {
     /// Get the NgPre specification version of the container.
-    async fn get_version(&self) -> Promise;
+    fn get_version(&self) -> JsValue;
 
-    async fn get_dataset_attributes(&self, path_name: &str) -> Promise;
+    fn get_dataset_attributes(&self, path_name: &str) -> JsValue;
 
-    async fn exists(&self, path_name: &str) -> Promise;
+    fn exists(&self, path_name: &str) -> bool;
 
-    async fn dataset_exists(&self, path_name: &str) -> Promise;
+    fn dataset_exists(&self, path_name: &str) -> bool;
 
     async fn read_block(
         &self,
         path_name: &str,
         data_attrs: &wrapped::DatasetAttributes,
         grid_position: Vec<i64>,
-    ) -> Promise;
+    ) -> JsValue;
 
-    async fn list_attributes(&self, path_name: &str) -> Promise;
+    fn list_attributes(&self, path_name: &str) -> JsValue;
 }
 
 impl<T> NgPrePromiseReader for T where T: NgPreAsyncReader {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,15 +180,16 @@ pub trait NgPreAsyncEtagReader {
 }
 
 pub mod wrapped {
+    use std::fmt;
+
     use super::*;
 
     #[wasm_bindgen]
     pub struct Version(pub(crate) ngpre::Version);
 
-    #[wasm_bindgen]
-    impl Version {
-        pub fn to_string(&self) -> String {
-            self.0.to_string()
+    impl fmt::Display for Version {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "{}", self.0)
         }
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,14 +1,10 @@
-use cfg_if::cfg_if;
-
-cfg_if! {
+pub fn set_panic_hook() {
     // When the `console_error_panic_hook` feature is enabled, we can call the
-    // `set_panic_hook` function to get better error messages if we ever panic.
-    if #[cfg(feature = "console_error_panic_hook")] {
-        extern crate console_error_panic_hook;
-        pub use self::console_error_panic_hook::set_once as set_panic_hook;
-    } else {
-        #[allow(dead_code)]
-        #[inline]
-        pub fn set_panic_hook() {}
-    }
+    // `set_panic_hook` function at least once during initialization, and then
+    // we will get better error messages if our code ever panics.
+    //
+    // For more details see
+    // https://github.com/rustwasm/console_error_panic_hook#readme
+    #[cfg(feature = "console_error_panic_hook")]
+    console_error_panic_hook::set_once();
 }


### PR DESCRIPTION
## Changes

This PR fixes the wrong return type from all the functions in the library. Because in #1, using `Async/Await` syntax wraps any type into `Promise<any>` javascript type when compiling to WASM.

Here's a result comparing the generated Typescript definitions for `Main` and `Sharding` branches:

**Main Branch**:
```ts
export class NgPreHTTPFetch {
  static open(base_path: string): Promise<any>;
}
```

**Sharding Branch**:
```ts
export class NgPreHTTPFetch {
  /**
  * @param {string} base_path
  * @returns {Promise<any>}
  */
  static open(base_path: string): Promise<Promise<any>>;
}
```

**After**:
```ts
export class NgPreHTTPFetch {
  /**
  * @param {string} base_path
  * @returns {Promise<any>}
  */
  static open(base_path: string): Promise<any>;
}
```

---

It also fixes some function return type to exactly mapped to javascript types:

**Main Branch**:
```ts
exists(path_name: string): Promise<any>;
dataset_exists(path_name: string): Promise<any>;
```

**Sharding Branch**:
```ts
/**
  * @param {string} path_name
  * @returns {boolean}
  */
exists(path_name: string): boolean;
/**
  * @param {string} path_name
  * @returns {boolean}
  */
dataset_exists(path_name: string): boolean;
```

As a result it significantly reduce the errors when testing the `sharded` branch on the `non-sharded` data in the CATMAID project.

This is the result testing the changes with `non-sharded` dataset:

**Before**:

![image](https://github.com/user-attachments/assets/7615ded2-8d13-4c46-b210-40e30f9a1646)

**After**:

![image](https://github.com/user-attachments/assets/1718dbd0-7c49-4915-a7fa-a05a68c1c293)
